### PR TITLE
Install xclip in base apps

### DIFF
--- a/arch/install/base/chroot/apps
+++ b/arch/install/base/chroot/apps
@@ -14,6 +14,9 @@ pacman -S base-devel make gcc --noconfirm
 pacman -S neovim ripgrep --noconfirm
 pacman -S ttf-nerd-fonts-symbols ttf-nerd-fonts-symbols-mono --noconfirm
 
+# Clipboard utility
+pacman -S xclip --noconfirm
+
 echo "--------------------------------------------------------------------------------"
 echo "Base apps were installed successfully"
 echo "Press Enter to  ontinue, or wait 5 seconds..."


### PR DESCRIPTION
## Summary
- add a pacman install step for `xclip`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842685a3e70832db002db2e256f88d2