### PR TITLE
Add LUKS support for zoltan profile

### DIFF
--- a/arch/install/base/install
+++ b/arch/install/base/install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pacstrap -K $FOLDER_MNT base linux linux-firmware --noconfirm
+pacstrap -K $FOLDER_MNT base linux linux-firmware cryptsetup --noconfirm
 
 echo "--------------------------------------------------------------------------------"
 echo "Base system install" 

--- a/arch/install/options/interpreter
+++ b/arch/install/options/interpreter
@@ -10,6 +10,7 @@ function usage() {
   echo " [--boot        | -b] bios  | uefi    The boot mode to be installed. Default value is uefi."
   echo " [--gui         | -g] gnome | dwm     Graphical user interface. Defaultly installs none."
   echo " [--vboxutils   | -v] false | true    Vbox Utils to run virtual machin inside a virtual box instance"
+  echo " [--luks        | -l] false | true    Encrypt partitions with LUKS"
 
   echo "Press Enter to  ontinue, or wait 5 seconds..."
   read -t 5 -n 1  # Wait for 5 seconds or a single keypress
@@ -18,6 +19,8 @@ function usage() {
 
 # default option values
 user=""
+luks=""
+luks_password=""
 boot=""
 disk=""
 gui=""
@@ -75,6 +78,17 @@ if [[ $# -gt 0 ]]; then
         vboxutils=$2
 
         if [[ $vboxutils != "true" ]] && [[ $vboxutils != "false" ]]; then
+          usage
+          exit 1
+        fi
+
+        shift 2
+        ;;
+
+      -l | --luks)
+        luks=$2
+
+        if [[ $luks != "true" ]] && [[ $luks != "false" ]]; then
           usage
           exit 1
         fi
@@ -160,13 +174,33 @@ while true; do
   fi
 done
 
-echo "--------------------------------------------------------------------------------"
+# Choose luks encryption option if not provided
+source options/lib/luks
+while true; do
+  if [[ -z "$luks" ]]; then
+    choose_luks_option
+  fi
+
+  if [[ -n "$luks" ]]; then
+      break
+  else
+      echo "Input cannot be empty. Please try again."
+  fi
+done
+
+if [[ "$luks" == "true" ]]; then
+  read -s -p "Enter LUKS password: " luks_password
+  echo
+fi
+
+echo "-----------------------------------------------------------------------"
 echo "Option interpreter"
 echo "boot:" $boot
 echo "disk:" $disk
 echo "gui: " $gui
 echo "user:" $user
 echo "vboxutils:" $vboxutils
+echo "luks:" $luks
 
 echo "Press Enter to  ontinue, or wait 5 seconds..."
 read -t 5 -n 1  # Wait for 5 seconds or a single keypress

--- a/arch/install/options/lib/luks
+++ b/arch/install/options/lib/luks
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+function choose_luks_option() {
+  echo "Would you like to encrypt the partitions with LUKS?"
+
+  options=("Yes" "No")
+
+  select choice in "${options[@]}"; do
+      case $choice in
+          "Yes")
+              luks="true"
+              break
+              ;;
+          "No")
+              luks="false"
+              break
+              ;;
+          *)
+              echo "Invalid option. Please try again."
+              ;;
+      esac
+  done
+}

--- a/arch/install/partition/lib/bios
+++ b/arch/install/partition/lib/bios
@@ -12,7 +12,14 @@ function create_partitions() {
 }
 
 function format_partitions() {
-  mkfs.ext4 ${disk}1
+  if [[ "$luks" == "true" ]]; then
+    echo -n "$luks_password" | cryptsetup luksFormat ${disk}1 -
+    echo -n "$luks_password" | cryptsetup open ${disk}1 cryptroot -
+    mkfs.ext4 /dev/mapper/cryptroot
+    cryptsetup close cryptroot
+  else
+    mkfs.ext4 ${disk}1
+  fi
 
   echo "--------------------------------------------------------------------------------"
   echo "Partitions on '$disk' device have been formatted" 
@@ -23,10 +30,19 @@ function format_partitions() {
 }
 
 function mount_partitions() {
-  mount ${disk}1 $FOLDER_MNT
+  if [[ "$luks" == "true" ]]; then
+    echo -n "$luks_password" | cryptsetup open ${disk}1 cryptroot -
+    mount /dev/mapper/cryptroot $FOLDER_MNT
+  else
+    mount ${disk}1 $FOLDER_MNT
+  fi
 
   echo "--------------------------------------------------------------------------------"
-  echo "Partition '${disk}1' has been mounted on $FOLDER_MNT" 
+  if [[ "$luks" == "true" ]]; then
+    echo "Partition '${disk}1' has been opened as cryptroot and mounted on $FOLDER_MNT"
+  else
+    echo "Partition '${disk}1' has been mounted on $FOLDER_MNT"
+  fi
 
   echo "Press Enter to  ontinue, or wait 5 seconds..."
   read -t 5 -n 1  # Wait for 5 seconds or a single keypress
@@ -34,9 +50,16 @@ function mount_partitions() {
 
 function umount_partitions() {
   umount -R $FOLDER_MNT
+  if [[ "$luks" == "true" ]]; then
+    cryptsetup close cryptroot
+  fi
 
   echo "--------------------------------------------------------------------------------"
-  echo "Partition '${disk}1' has been umounted from $FOLDER_MNT" 
+  if [[ "$luks" == "true" ]]; then
+    echo "cryptroot has been closed and unmounted from $FOLDER_MNT"
+  else
+    echo "Partition '${disk}1' has been umounted from $FOLDER_MNT"
+  fi
 
   echo "Press Enter to  ontinue, or wait 5 seconds..."
   read -t 5 -n 1  # Wait for 5 seconds or a single keypress

--- a/arch/install/partition/lib/uefi
+++ b/arch/install/partition/lib/uefi
@@ -13,7 +13,15 @@ function create_partitions() {
 
 function format_partitions() {
   mkfs.fat -F 32 ${disk}1
-  mkfs.ext4 ${disk}2
+
+  if [[ "$luks" == "true" ]]; then
+    echo -n "$luks_password" | cryptsetup luksFormat ${disk}2 -
+    echo -n "$luks_password" | cryptsetup open ${disk}2 cryptroot -
+    mkfs.ext4 /dev/mapper/cryptroot
+    cryptsetup close cryptroot
+  else
+    mkfs.ext4 ${disk}2
+  fi
 
   echo "--------------------------------------------------------------------------------"
   echo "Partitions on '$disk' device have been formatted" 
@@ -24,12 +32,21 @@ function format_partitions() {
 }
 
 function mount_partitions() {
-  mount ${disk}2 $FOLDER_MNT
+  if [[ "$luks" == "true" ]]; then
+    echo -n "$luks_password" | cryptsetup open ${disk}2 cryptroot -
+    mount /dev/mapper/cryptroot $FOLDER_MNT
+  else
+    mount ${disk}2 $FOLDER_MNT
+  fi
   mount --mkdir ${disk}1 $FOLDER_MNT/boot/efi
 
   echo "--------------------------------------------------------------------------------"
-  echo "Partition '${disk}1' has been mounted on $FOLDER_MNT" 
-  echo "Partition '${disk}2' has been mounted on $FOLDER_MNT/boot/efi" 
+  if [[ "$luks" == "true" ]]; then
+    echo "Partition '${disk}2' has been opened as cryptroot and mounted on $FOLDER_MNT"
+  else
+    echo "Partition '${disk}2' has been mounted on $FOLDER_MNT"
+  fi
+  echo "Partition '${disk}1' has been mounted on $FOLDER_MNT/boot/efi"
 
   echo "Press Enter to  ontinue, or wait 5 seconds..."
   read -t 5 -n 1  # Wait for 5 seconds or a single keypress
@@ -38,10 +55,17 @@ function mount_partitions() {
 function umount_partitions() {
   umount -R $FOLDER_MNT/boot/efi
   umount -R $FOLDER_MNT
+  if [[ "$luks" == "true" ]]; then
+    cryptsetup close cryptroot
+  fi
 
   echo "--------------------------------------------------------------------------------"
-  echo "Partition '${disk}2' has been umounted from $FOLDER_MNT/boot/efi" 
-  echo "Partition '${disk}1' has been umounted from $FOLDER_MNT" 
+  echo "Partition '${disk}1' has been umounted from $FOLDER_MNT/boot/efi"
+  if [[ "$luks" == "true" ]]; then
+    echo "cryptroot has been closed and unmounted from $FOLDER_MNT"
+  else
+    echo "Partition '${disk}2' has been umounted from $FOLDER_MNT"
+  fi
 
   echo "Press Enter to  ontinue, or wait 5 seconds..."
   read -t 5 -n 1  # Wait for 5 seconds or a single keypress

--- a/arch/install/profiles/zoltan
+++ b/arch/install/profiles/zoltan
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-set -- --boot uefi --disk /dev/sda --gui gnome --user zoltan --vboxutils false 
+set -- --boot uefi --disk /dev/sda --gui gnome --user zoltan --vboxutils false --luks true
 source options/interpreter
+
 
 source common/distro
 source common/globals


### PR DESCRIPTION
## Summary
- prompt for optional LUKS encryption via new `--luks` option
- store password in `luks_password`
- update partition scripts to use `luks_password`
- simplify `choose_luks_option` to only allow yes or no
- pass `--luks true` in zoltan profile

## Testing
- `bash -n arch/install/options/interpreter`
- `bash -n arch/install/partition/lib/bios`
- `bash -n arch/install/partition/lib/uefi`
- `bash -n arch/install/profiles/zoltan`
- `bash -n arch/install/options/lib/luks`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ac7e06004832d83e2bf3145245a5e