### PR TITLE
Fix LUKS boot configuration

### DIFF
--- a/arch/install/base/chroot-install
+++ b/arch/install/base/chroot-install
@@ -4,7 +4,7 @@ mkdir -p $FOLDER_MNT/root/$FOLDER_INSTALL/base
 mount --bind base/chroot $FOLDER_MNT/root/$FOLDER_INSTALL/base
 
 # Configure booting
-arch-chroot $FOLDER_MNT env disk="$disk" /bin/bash -c "~/$FOLDER_INSTALL/base/configure/$boot"
+arch-chroot $FOLDER_MNT env disk="$disk" luks="$luks" /bin/bash -c "~/$FOLDER_INSTALL/base/configure/$boot"
 
 # Install basic applications
 arch-chroot $FOLDER_MNT /bin/bash -c "~/$FOLDER_INSTALL/base/apps"

--- a/arch/install/base/chroot/configure/bios
+++ b/arch/install/base/chroot/configure/bios
@@ -29,10 +29,18 @@ pacman-key --populate
 pacman -Sy archlinux-keyring --noconfirm
 
 # Init ramfs
+root_partition="${disk}1"
+if [[ "$luks" == "true" ]]; then
+  sed -i 's/block/block encrypt/' /etc/mkinitcpio.conf
+fi
 mkinitcpio -P
 
 # Grub boot loader
 pacman -S grub --noconfirm
+if [[ "$luks" == "true" ]]; then
+  uuid=$(blkid -s UUID -o value "$root_partition")
+  sed -i "s#^GRUB_CMDLINE_LINUX=.*#GRUB_CMDLINE_LINUX=\"cryptdevice=UUID=$uuid:cryptroot root=/dev/mapper/cryptroot\"#" /etc/default/grub
+fi
 
 # Grub install
 grub-install --target=i386-pc $disk

--- a/arch/install/base/chroot/configure/uefi
+++ b/arch/install/base/chroot/configure/uefi
@@ -29,10 +29,18 @@ pacman-key --populate
 pacman -Sy archlinux-keyring --noconfirm
 
 # Init ramfs
+root_partition="${disk}2"
+if [[ "$luks" == "true" ]]; then
+  sed -i 's/block/block encrypt/' /etc/mkinitcpio.conf
+fi
 mkinitcpio -P
 
 # Grub boot loader
 pacman -S grub --noconfirm
+if [[ "$luks" == "true" ]]; then
+  uuid=$(blkid -s UUID -o value "$root_partition")
+  sed -i "s#^GRUB_CMDLINE_LINUX=.*#GRUB_CMDLINE_LINUX=\"cryptdevice=UUID=$uuid:cryptroot root=/dev/mapper/cryptroot\"#" /etc/default/grub
+fi
 
 # Grub install
 pacman -S efibootmgr --noconfirm

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,10 @@
     ```
 4. Install git in order to clone the install script: `pacman -Sy git --noconfirm`
 5. Clone the install script: `git clone https://github.com/devbysp/linux`
-6. Run the install with the command 
+6. Run the install with the command
     ```shell
     cd arch/install
     ./install
     ```
 7. Select a profile to be installed
+   - The installer creates an unencrypted `/boot/efi` partition and can optionally encrypt the root partition with LUKS.


### PR DESCRIPTION
## Summary
- pass luks flag to chroot configuration
- configure mkinitcpio and grub when luks encryption is selected
- mention unencrypted `/boot/efi` in README

## Testing
- `bash -n arch/install/base/chroot-install`
- `bash -n arch/install/base/chroot/configure/uefi`
- `bash -n arch/install/base/chroot/configure/bios`


------
https://chatgpt.com/codex/tasks/task_e_6869b6618690832dad5bec31fce6e4a9